### PR TITLE
config: Update from / for the module template

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,5 +38,5 @@ jobs:
       id-token: write
 
     with:
-      bazel-target: "//docs:github_pages"
+      bazel-target: "//docs:incremental -- --github_user=${{ github.repository_owner }} --github_repo=${{ github.event.repository.name }}"
       retention-days: 3

--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -1,0 +1,32 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Gitlint check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  lint-commits:
+    name: check-commit-messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run Gitlint Action
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: ./.github/actions/gitlint
+        with:
+          pr-number: ${{ github.event.number }}
+          base-branch: ${{ github.event.pull_request.base.ref }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ module(
     version = "1.0",
 )
 
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.4.1")
 
 PYTHON_VERSION = "3.12"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,4 +60,4 @@ bazel_dep(name = "aspect_rules_lint", version = "1.0.3")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 
 #docs-as-code
-bazel_dep(name = "score_docs_as_code", version = "0.2.4")
+bazel_dep(name = "score_docs_as_code", version = "0.3.3")


### PR DESCRIPTION
- Update docs_as_code module to version 0.3.3 and usage in the according docs workflow.
- gitlint: Use provided file from template
- update rules_python to 1.4.1