### PR TITLE
Add non-generic get_value implementation

### DIFF
--- a/src/rust/rust_kvs/src/lib.rs
+++ b/src/rust/rust_kvs/src/lib.rs
@@ -411,7 +411,7 @@ impl From<TryFromSliceError> for ErrorCode {
 
 impl From<Vec<u8>> for ErrorCode {
     fn from(cause: Vec<u8>) -> Self {
-        eprintln!("error: try_into from u8 vector failed: {:#?}", cause);
+        eprintln!("error: try_into from u8 vector failed: {cause:#?}");
         ErrorCode::ConversionFailed
     }
 }

--- a/src/rust/rust_kvs/tests/cit_persistency.rs
+++ b/src/rust/rust_kvs/tests/cit_persistency.rs
@@ -12,7 +12,7 @@ use std::iter::zip;
 use tempfile::tempdir;
 
 fn cmp_match(left: &KvsValue, right: &KvsValue) -> bool {
-    return match (left, right) {
+    match (left, right) {
         (KvsValue::Number(l), KvsValue::Number(r)) => l == r,
         (KvsValue::Boolean(l), KvsValue::Boolean(r)) => l == r,
         (KvsValue::String(l), KvsValue::String(r)) => l == r,
@@ -54,7 +54,7 @@ fn cmp_match(left: &KvsValue, right: &KvsValue) -> bool {
             true
         }
         (_, _) => false,
-    };
+    }
 }
 
 fn cmp_object(left: HashMap<String, KvsValue>, right: HashMap<String, KvsValue>) -> bool {

--- a/src/rust/rust_kvs/tests/kvs_default_values.rs
+++ b/src/rust/rust_kvs/tests/kvs_default_values.rs
@@ -55,14 +55,14 @@ fn kvs_without_defaults() -> Result<(), ErrorCode> {
     kvs.set_value("bool2", false)?;
     kvs.set_value("string2", "Ola".to_string())?;
 
-    assert_eq!(kvs.get_value::<f64>("number1")?, 123.0);
-    assert_eq!(kvs.get_value::<f64>("number2")?, 345.0);
+    assert_eq!(kvs.get_value_as::<f64>("number1")?, 123.0);
+    assert_eq!(kvs.get_value_as::<f64>("number2")?, 345.0);
 
-    assert!(kvs.get_value::<bool>("bool1")?);
-    assert!(!kvs.get_value::<bool>("bool2")?);
+    assert!(kvs.get_value_as::<bool>("bool1")?);
+    assert!(!kvs.get_value_as::<bool>("bool2")?);
 
-    assert_eq!(kvs.get_value::<String>("string1")?, "Hello".to_string());
-    assert_eq!(kvs.get_value::<String>("string2")?, "Ola".to_string());
+    assert_eq!(kvs.get_value_as::<String>("string1")?, "Hello".to_string());
+    assert_eq!(kvs.get_value_as::<String>("string2")?, "Ola".to_string());
 
     assert!(kvs.is_value_default("number1")?);
     assert!(!kvs.is_value_default("number2")?);
@@ -87,10 +87,13 @@ fn kvs_without_defaults() -> Result<(), ErrorCode> {
         .need_kvs(true)
         .build()?;
 
-    assert!(kvs.get_value::<bool>("bool1")?);
+    assert!(kvs.get_value_as::<bool>("bool1")?);
     assert!(!kvs.is_value_default("bool1")?);
 
-    assert_eq!(kvs.get_value::<String>("string1")?, "Bonjour".to_string());
+    assert_eq!(
+        kvs.get_value_as::<String>("string1")?,
+        "Bonjour".to_string()
+    );
     assert!(!kvs.is_value_default("string1")?);
 
     // drop the current instance with flush-on-exit enabled and reopen storage
@@ -117,10 +120,10 @@ fn kvs_without_defaults() -> Result<(), ErrorCode> {
         .need_kvs(true)
         .build()?;
 
-    assert_eq!(kvs.get_value::<f64>("number1")?, 987.0);
+    assert_eq!(kvs.get_value_as::<f64>("number1")?, 987.0);
     assert!(kvs.is_value_default("number1")?);
 
-    assert!(kvs.get_value::<bool>("bool1")?);
+    assert!(kvs.get_value_as::<bool>("bool1")?);
     assert!(!kvs.is_value_default("bool1")?);
 
     Ok(())

--- a/src/rust/rust_kvs/tests/kvs_new_wo_defaults.rs
+++ b/src/rust/rust_kvs/tests/kvs_new_wo_defaults.rs
@@ -65,17 +65,17 @@ fn kvs_without_defaults() -> Result<(), ErrorCode> {
         .need_kvs(true)
         .build()?;
 
-    assert_eq!(kvs.get_value::<f64>("number")?, 123.0);
-    assert!(kvs.get_value::<bool>("bool")?);
-    assert_eq!(kvs.get_value::<String>("string")?, "Hello");
-    assert_eq!(kvs.get_value::<()>("null"), Ok(()));
+    assert_eq!(kvs.get_value_as::<f64>("number")?, 123.0);
+    assert!(kvs.get_value_as::<bool>("bool")?);
+    assert_eq!(kvs.get_value_as::<String>("string")?, "Hello");
+    assert_eq!(kvs.get_value_as::<()>("null"), Ok(()));
 
-    let json_array = kvs.get_value::<Vec<KvsValue>>("array")?;
+    let json_array = kvs.get_value_as::<Vec<KvsValue>>("array")?;
     assert_eq!(json_array[0].get(), Some(&456.0));
     assert_eq!(json_array[1].get(), Some(&false));
     assert_eq!(json_array[2].get(), Some(&"Bye".to_string()));
 
-    let json_map = kvs.get_value::<HashMap<String, KvsValue>>("object")?;
+    let json_map = kvs.get_value_as::<HashMap<String, KvsValue>>("object")?;
     assert_eq!(json_map["sub-number"].get(), Some(&789.0));
     assert_eq!(json_map["sub-bool"].get(), Some(&true));
     assert_eq!(json_map["sub-string"].get(), Some(&"Hi".to_string()));
@@ -88,7 +88,7 @@ fn kvs_without_defaults() -> Result<(), ErrorCode> {
 
     // test for non-existent values
     assert_eq!(
-        kvs.get_value::<String>("non-existent").err(),
+        kvs.get_value_as::<String>("non-existent").err(),
         Some(ErrorCode::KeyNotFound)
     );
 

--- a/src/rust/rust_kvs/tests/kvs_new_wo_defaults_builder.rs
+++ b/src/rust/rust_kvs/tests/kvs_new_wo_defaults_builder.rs
@@ -65,17 +65,17 @@ fn kvs_without_defaults_builder() -> Result<(), ErrorCode> {
     let builder = builder.need_kvs(true);
     let kvs = builder.build()?;
 
-    assert_eq!(kvs.get_value::<f64>("number")?, 123.0);
-    assert!(kvs.get_value::<bool>("bool")?);
-    assert_eq!(kvs.get_value::<String>("string")?, "Hello");
-    assert_eq!(kvs.get_value::<()>("null"), Ok(()));
+    assert_eq!(kvs.get_value_as::<f64>("number")?, 123.0);
+    assert!(kvs.get_value_as::<bool>("bool")?);
+    assert_eq!(kvs.get_value_as::<String>("string")?, "Hello");
+    assert_eq!(kvs.get_value_as::<()>("null"), Ok(()));
 
-    let json_array = kvs.get_value::<Vec<KvsValue>>("array")?;
+    let json_array = kvs.get_value_as::<Vec<KvsValue>>("array")?;
     assert_eq!(json_array[0].get(), Some(&456.0));
     assert_eq!(json_array[1].get(), Some(&false));
     assert_eq!(json_array[2].get(), Some(&"Bye".to_string()));
 
-    let json_map = kvs.get_value::<HashMap<String, KvsValue>>("object")?;
+    let json_map = kvs.get_value_as::<HashMap<String, KvsValue>>("object")?;
     assert_eq!(json_map["sub-number"].get(), Some(&789.0));
     assert_eq!(json_map["sub-bool"].get(), Some(&true));
     assert_eq!(json_map["sub-string"].get(), Some(&"Hi".to_string()));
@@ -88,7 +88,7 @@ fn kvs_without_defaults_builder() -> Result<(), ErrorCode> {
 
     // test for non-existent values
     assert_eq!(
-        kvs.get_value::<String>("non-existent").err(),
+        kvs.get_value_as::<String>("non-existent").err(),
         Some(ErrorCode::KeyNotFound)
     );
 

--- a/src/rust/rust_kvs/tests/kvs_snapshot_restore.rs
+++ b/src/rust/rust_kvs/tests/kvs_snapshot_restore.rs
@@ -51,7 +51,7 @@ fn kvs_snapshot_restore() -> Result<(), ErrorCode> {
     // restore snapshots and check `counter` value
     for idx in 1..=max_count {
         kvs.snapshot_restore(SnapshotId::new(idx))?;
-        assert_eq!(kvs.get_value::<f64>("counter")?, (counter - idx) as f64);
+        assert_eq!(kvs.get_value_as::<f64>("counter")?, (counter - idx) as f64);
     }
 
     Ok(())

--- a/src/rust/rust_kvs_tool/src/kvs_tool.rs
+++ b/src/rust/rust_kvs_tool/src/kvs_tool.rs
@@ -80,10 +80,7 @@
 //!
 
 use pico_args::Arguments;
-use rust_kvs::{
-    ErrorCode, InstanceId, Kvs, KvsApi, KvsBuilder, KvsValue, OpenNeedDefaults, OpenNeedKvs,
-    SnapshotId,
-};
+use rust_kvs::{ErrorCode, InstanceId, Kvs, KvsApi, KvsBuilder, KvsValue, SnapshotId};
 use std::collections::HashMap;
 use tinyjson::JsonValue;
 
@@ -154,19 +151,19 @@ fn _getkey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
     println!("Read Key {}", &key);
 
     let key_exist = kvs.key_exists(&key).map_err(|e| {
-        eprintln!("KVS get:key_exists failed: {:?}", e);
+        eprintln!("KVS get:key_exists failed: {e:?}");
         e
     })?;
 
     let is_default = kvs.is_value_default(&key).map_err(|e| {
-        eprintln!("KVS get:is_value_default failed: {:?}", e);
+        eprintln!("KVS get:is_value_default failed: {e:?}");
         e
     })?;
 
     if key_exist {
-        println!("Key '{}' exists!", key);
+        println!("Key '{key}' exists!");
     } else {
-        println!("Key '{}' does not exist!", key);
+        println!("Key '{key}' does not exist!");
         if is_default {
             println!("Key is default value!");
         } else {
@@ -177,10 +174,10 @@ fn _getkey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
 
     match kvs.get_default_value(&key) {
         Ok(value) => {
-            println!("Default Value: {:?}", value);
+            println!("Default Value: {value:?}");
         }
         Err(e) => {
-            eprintln!("Default Value Error: {:?}", e);
+            eprintln!("Default Value Error: {e:?}");
         }
     };
 
@@ -212,48 +209,48 @@ fn _getkey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
     match get_mode {
         SupportedTypes::Number => {
             let value = kvs.get_value::<f64>(&key).map_err(|e| {
-                eprintln!("KVS get failed: {:?}", e);
+                eprintln!("KVS get failed: {e:?}");
                 e
             })?;
-            println!("Key:'{}' \nValue: {}", key, value);
+            println!("Key:'{key}' \nValue: {value}");
         }
         SupportedTypes::Bool => {
             let value = kvs.get_value::<bool>(&key).map_err(|e| {
-                eprintln!("KVS get failed: {:?}", e);
+                eprintln!("KVS get failed: {e:?}");
                 e
             })?;
-            println!("Key:'{}' \nValue: {}", key, value);
+            println!("Key:'{key}' \nValue: {value}");
         }
         SupportedTypes::String => {
             let value = kvs.get_value::<String>(&key).map_err(|e| {
-                eprintln!("KVS get failed: {:?}", e);
+                eprintln!("KVS get failed: {e:?}");
                 e
             })?;
-            println!("Key:'{}' \nValue: {}", key, value);
+            println!("Key:'{key}' \nValue: {value}");
         }
         // Different Syntax to be compliant with "clippy::let_unit_value"
         SupportedTypes::Null => {
             kvs.get_value::<()>(&key).map_err(|e| {
-                eprintln!("KVS get failed: {:?}", e);
+                eprintln!("KVS get failed: {e:?}");
                 e
             })?;
             println!("Key:'{}' \nValue: {:?}", key, ());
         }
         SupportedTypes::Array => {
             let value = kvs.get_value::<Vec<KvsValue>>(&key).map_err(|e| {
-                eprintln!("KVS get failed: {:?}", e);
+                eprintln!("KVS get failed: {e:?}");
                 e
             })?;
-            println!("Key:'{}' \nValue: {:?}", key, value);
+            println!("Key:'{key}' \nValue: {value:?}");
         }
         SupportedTypes::Object => {
             let value = kvs
                 .get_value::<HashMap<String, KvsValue>>(&key)
                 .map_err(|e| {
-                    eprintln!("KVS get failed: {:?}", e);
+                    eprintln!("KVS get failed: {e:?}");
                     e
                 })?;
-            println!("Key:'{}' \nValue: {:?}", key, value);
+            println!("Key:'{key}' \nValue: {value:?}");
         }
 
         SupportedTypes::Invalid => {
@@ -302,20 +299,20 @@ fn _setkey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
                 let kvs_val = from_tinyjson(&json_val);
                 println!("Key:'{}' \nParsed as JSON Value: {:?}", &key, kvs_val);
                 kvs.set_value(key, kvs_val).map_err(|e| {
-                    eprintln!("KVS set failed: {:?}", e);
+                    eprintln!("KVS set failed: {e:?}");
                     e
                 })?;
             } else {
                 println!("Key:'{}' \nParsed as String Value: {}", &key, value);
                 kvs.set_value(key, KvsValue::String(value)).map_err(|e| {
-                    eprintln!("KVS set failed: {:?}", e);
+                    eprintln!("KVS set failed: {e:?}");
                     e
                 })?;
             }
         }
         None => {
             kvs.set_value(key, KvsValue::Null).map_err(|e| {
-                eprintln!("KVS set failed: {:?}", e);
+                eprintln!("KVS set failed: {e:?}");
                 e
             })?;
         }
@@ -340,7 +337,7 @@ fn _removekey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
     };
     println!("Remove Key {}", &key);
     kvs.remove_key(&key).map_err(|e| {
-        eprintln!("KVS remove failed: {:?}", e);
+        eprintln!("KVS remove failed: {e:?}");
         e
     })?;
     println!("----------------------");
@@ -354,12 +351,12 @@ fn _listkeys(kvs: Kvs) -> Result<(), ErrorCode> {
     println!("List Keys");
 
     let keys = kvs.get_all_keys().map_err(|e| {
-        eprintln!("KVS list failed: {:?}", e);
+        eprintln!("KVS list failed: {e:?}");
         e
     })?;
 
     for key in keys {
-        println!("{}", key);
+        println!("{key}");
     }
 
     println!("----------------------");
@@ -371,7 +368,7 @@ fn _reset(kvs: Kvs) -> Result<(), ErrorCode> {
     println!("----------------------");
     println!("Reset KVS");
     kvs.reset().map_err(|e| {
-        eprintln!("KVS set failed: {:?}", e);
+        eprintln!("KVS set failed: {e:?}");
         e
     })?;
     println!("----------------------");
@@ -383,7 +380,7 @@ fn _snapshotcount(kvs: Kvs) -> Result<(), ErrorCode> {
     println!("----------------------");
     println!("Snapshot Count");
     let count = kvs.snapshot_count();
-    println!("Snapshot Count: {}", count);
+    println!("Snapshot Count: {count}");
     println!("----------------------");
     Ok(())
 }
@@ -393,7 +390,7 @@ fn _snapshotmaxcount() -> Result<(), ErrorCode> {
     println!("----------------------");
     println!("Snapshots Max Count");
     let max = Kvs::snapshot_max_count();
-    println!("Snapshots Maximum Count: {}", max);
+    println!("Snapshots Maximum Count: {max}");
     println!("----------------------");
     Ok(())
 }
@@ -417,7 +414,7 @@ fn _snapshotrestore(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
     println!("Restore Snapshot {}", &snapshot_id);
     let snapshot_id = SnapshotId::new(snapshot_id as usize);
     kvs.snapshot_restore(snapshot_id).map_err(|e| {
-        eprintln!("KVS restore failed: {:?}", e);
+        eprintln!("KVS restore failed: {e:?}");
         e
     })?;
     println!("----------------------");
@@ -440,7 +437,7 @@ fn _getkvsfilename(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
     };
     let snapshot_id = SnapshotId::new(snapshot_id as usize);
     let filename = kvs.get_kvs_filename(snapshot_id);
-    println!("KVS Filename: {}", filename);
+    println!("KVS Filename: {filename}");
     println!("----------------------");
     Ok(())
 }
@@ -462,7 +459,7 @@ fn _gethashfilename(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
     };
     let snapshot_id = SnapshotId::new(snapshot_id as usize);
     let filename = kvs.get_hash_filename(snapshot_id);
-    println!("Hash Filename: {}", filename);
+    println!("Hash Filename: {filename}");
     println!("----------------------");
     Ok(())
 }
@@ -473,19 +470,19 @@ fn _createtestdata(kvs: Kvs) -> Result<(), ErrorCode> {
     println!("Create Test Data");
 
     kvs.set_value("number", 123.0).map_err(|e| {
-        eprintln!("KVS Create Test Data Error (number): {:?}", e);
+        eprintln!("KVS Create Test Data Error (number): {e:?}");
         e
     })?;
     kvs.set_value("bool", true).map_err(|e| {
-        eprintln!("KVS Create Test Data Error (bool): {:?}", e);
+        eprintln!("KVS Create Test Data Error (bool): {e:?}");
         e
     })?;
     kvs.set_value("string", "First".to_string()).map_err(|e| {
-        eprintln!("KVS Create Test Data Error (string): {:?}", e);
+        eprintln!("KVS Create Test Data Error (string): {e:?}");
         e
     })?;
     kvs.set_value("null", ()).map_err(|e| {
-        eprintln!("KVS Create Test Data Error (null): {:?}", e);
+        eprintln!("KVS Create Test Data Error (null): {e:?}");
         e
     })?;
     kvs.set_value(
@@ -497,7 +494,7 @@ fn _createtestdata(kvs: Kvs) -> Result<(), ErrorCode> {
         ],
     )
     .map_err(|e| {
-        eprintln!("KVS Create Test Data Error (array): {:?}", e);
+        eprintln!("KVS Create Test Data Error (array): {e:?}");
         e
     })?;
     kvs.set_value(
@@ -518,7 +515,7 @@ fn _createtestdata(kvs: Kvs) -> Result<(), ErrorCode> {
         ]),
     )
     .map_err(|e| {
-        eprintln!("KVS Create Test Data Error (object): {:?}", e);
+        eprintln!("KVS Create Test Data Error (object): {e:?}");
         e
     })?;
     println!("Done!");
@@ -537,7 +534,7 @@ fn main() -> Result<(), ErrorCode> {
     let kvs = match builder.build() {
         Ok(kvs) => kvs,
         Err(e) => {
-            eprintln!("Error opening KVS: {:?}", e);
+            eprintln!("Error opening KVS: {e:?}");
             return Err(e);
         }
     };
@@ -611,7 +608,7 @@ fn main() -> Result<(), ErrorCode> {
         ---------------------------------------
 
         "#;
-        println!("{}", HELP);
+        println!("{HELP}");
         return Ok(());
     }
     let operation: Option<String> = match args.opt_value_from_str("--operation") {

--- a/src/rust/rust_kvs_tool/src/kvs_tool.rs
+++ b/src/rust/rust_kvs_tool/src/kvs_tool.rs
@@ -208,21 +208,21 @@ fn _getkey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
 
     match get_mode {
         SupportedTypes::Number => {
-            let value = kvs.get_value::<f64>(&key).map_err(|e| {
+            let value = kvs.get_value_as::<f64>(&key).map_err(|e| {
                 eprintln!("KVS get failed: {e:?}");
                 e
             })?;
             println!("Key:'{key}' \nValue: {value}");
         }
         SupportedTypes::Bool => {
-            let value = kvs.get_value::<bool>(&key).map_err(|e| {
+            let value = kvs.get_value_as::<bool>(&key).map_err(|e| {
                 eprintln!("KVS get failed: {e:?}");
                 e
             })?;
             println!("Key:'{key}' \nValue: {value}");
         }
         SupportedTypes::String => {
-            let value = kvs.get_value::<String>(&key).map_err(|e| {
+            let value = kvs.get_value_as::<String>(&key).map_err(|e| {
                 eprintln!("KVS get failed: {e:?}");
                 e
             })?;
@@ -230,14 +230,14 @@ fn _getkey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
         }
         // Different Syntax to be compliant with "clippy::let_unit_value"
         SupportedTypes::Null => {
-            kvs.get_value::<()>(&key).map_err(|e| {
+            kvs.get_value_as::<()>(&key).map_err(|e| {
                 eprintln!("KVS get failed: {e:?}");
                 e
             })?;
             println!("Key:'{}' \nValue: {:?}", key, ());
         }
         SupportedTypes::Array => {
-            let value = kvs.get_value::<Vec<KvsValue>>(&key).map_err(|e| {
+            let value = kvs.get_value_as::<Vec<KvsValue>>(&key).map_err(|e| {
                 eprintln!("KVS get failed: {e:?}");
                 e
             })?;
@@ -245,7 +245,7 @@ fn _getkey(kvs: Kvs, mut args: Arguments) -> Result<(), ErrorCode> {
         }
         SupportedTypes::Object => {
             let value = kvs
-                .get_value::<HashMap<String, KvsValue>>(&key)
+                .get_value_as::<HashMap<String, KvsValue>>(&key)
                 .map_err(|e| {
                     eprintln!("KVS get failed: {e:?}");
                     e


### PR DESCRIPTION
More flexible `get_value` implementation.
Previous version renamed to `get_value_as`.