### PR TITLE
update kvsvalue to use pointers

### DIFF
--- a/src/cpp/src/internal/kvs_helper.cpp
+++ b/src/cpp/src/internal/kvs_helper.cpp
@@ -15,7 +15,7 @@
 namespace score::mw::per::kvs {
 
 /*********************** Hash Functions *********************/
-/*Adler 32 checksum algorithm*/ 
+/*Adler 32 checksum algorithm*/
 // Optimized version: processes data in blocks to reduce modulo operations
 uint32_t calculate_hash_adler32(const std::string& data) {
     constexpr size_t ADLER32_NMAX = 5552;
@@ -38,7 +38,7 @@ uint32_t calculate_hash_adler32(const std::string& data) {
     return (b << 16) | a;
 }
 
-/*Parse Adler32 checksum Byte-Array to uint32 */ 
+/*Parse Adler32 checksum Byte-Array to uint32 */
 uint32_t parse_hash_adler32(std::istream& in)
 {
     std::array<uint8_t,4> buf{};
@@ -51,7 +51,7 @@ uint32_t parse_hash_adler32(std::istream& in)
     return value;
 }
 
-/* Split uint32 checksum in bytes for writing*/ 
+/* Split uint32 checksum in bytes for writing*/
 std::array<uint8_t,4> get_hash_bytes_adler32(uint32_t hash)
 {
     std::array<uint8_t, 4> value = {
@@ -85,7 +85,7 @@ bool check_hash(const std::string& data_calculate, std::istream& data_parse){
         result = false;
     }
 
-    return result; 
+    return result;
 }
 
 /*********************** Standalone Helper Functions *********************/
@@ -177,7 +177,7 @@ score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any){
                                 result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                                 break;
                             }
-                            arr.emplace_back(std::move(conv.value()));
+                            arr.emplace_back(std::make_shared<KvsValue>(std::move(conv.value())));
                         }
                         if (!error){
                             result = KvsValue(std::move(arr));
@@ -197,7 +197,7 @@ score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any){
                                 result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                                 break;
                             }
-                            map.emplace(key.GetAsStringView().to_string(), std::move(conv.value()));
+                            map.emplace(key.GetAsStringView().to_string(), std::make_shared<KvsValue>(std::move(conv.value())));
                         }
                         if (!error) {
                             result = KvsValue(std::move(map));
@@ -271,7 +271,7 @@ score::Result<score::json::Any> kvsvalue_to_any(const KvsValue& kv) {
             obj.emplace("t", score::json::Any(std::string("arr")));
             score::json::List list;
             for (auto& elem : std::get<KvsValue::Array>(kv.getValue())) {
-                auto conv = kvsvalue_to_any(elem);
+                auto conv = kvsvalue_to_any(*elem);
                 if (!conv) {
                     result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     error = true;
@@ -288,7 +288,7 @@ score::Result<score::json::Any> kvsvalue_to_any(const KvsValue& kv) {
             obj.emplace("t", score::json::Any(std::string("obj")));
             score::json::Object inner_obj;
             for (auto& [key, value] : std::get<KvsValue::Object>(kv.getValue())) {
-                auto conv = kvsvalue_to_any(value);
+                auto conv = kvsvalue_to_any(*value);
                 if (!conv) {
                     result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     error = true;

--- a/src/cpp/src/kvsvalue.cpp
+++ b/src/cpp/src/kvsvalue.cpp
@@ -11,3 +11,92 @@
 * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 #include "kvsvalue.hpp"
+
+namespace score::mw::per::kvs {
+
+KvsValue::KvsValue(const Array& array){
+    Array shared_array;
+    shared_array.reserve(array.size());
+    for (const auto& item : array) {
+        shared_array.push_back(std::make_shared<KvsValue>(*item));
+    }
+    value = std::move(shared_array);
+    type = Type::Array;
+}
+
+KvsValue::KvsValue(const Object& object) {
+    Object shared_object;
+    for (const auto& [key, value] : object) {
+        shared_object[key] = std::make_shared<KvsValue>(*value);
+    }
+    value = std::move(shared_object);
+    type = Type::Object;
+}
+
+KvsValue::KvsValue(const std::vector<KvsValue>& array) {
+    Array shared_array;
+    shared_array.reserve(array.size());  // Reserve space for N elements
+    for (const auto& item : array) {
+        shared_array.emplace_back(std::make_shared<KvsValue>(item));
+    }
+    value = std::move(shared_array);
+    type = Type::Array;
+}
+
+KvsValue::KvsValue(const std::unordered_map<std::string, KvsValue>& object) {
+    Object shared_object;
+    for (const auto& [key, value] : object) {
+        shared_object[key] = std::make_shared<KvsValue>(value);
+    }
+    value = std::move(shared_object);
+    type = Type::Object;
+}
+
+/* copy constructor */
+KvsValue::KvsValue(const KvsValue& other) : type(other.type) {
+    switch(other.type){
+        case Type::Array:{
+            const Array& otherArray = std::get<Array>(other.value);
+            Array copiedArray;
+            copiedArray.reserve(otherArray.size());
+            for (const auto& item : otherArray) {
+                copiedArray.push_back(std::make_shared<KvsValue>(*item));
+            }
+            value = std::move(copiedArray);
+            break;
+        }
+        case Type::Object:{
+            const Object& otherObject = std::get<Object>(other.value);
+            Object copiedObject;
+            for (const auto& [key, value] : otherObject) {
+                copiedObject[key] = std::make_shared<KvsValue>(*value);
+            }
+            value = std::move(copiedObject);
+            break;
+        }
+        default:
+            value = other.value; // For other types, just copy the value
+            break;
+    }
+}
+
+/* copy Assignment Operator */
+KvsValue& KvsValue::operator=(const KvsValue& other) {
+    if (this != &other) {
+        KvsValue temp(other); // deep copy
+        std::swap(value, temp.value);
+        type = other.type;
+    }
+    return *this;
+}
+
+/* move Assignment Operator */
+KvsValue& KvsValue::operator=(KvsValue&& other) noexcept {
+    if (this != &other) {
+        value = std::move(other.value);
+        type = other.type;
+    }
+    return *this;
+}
+
+} /* end namespace score::mw::per::kvs */

--- a/src/cpp/src/kvsvalue.hpp
+++ b/src/cpp/src/kvsvalue.hpp
@@ -24,13 +24,13 @@ namespace score::mw::per::kvs {
 /* Define the KvsValue class*/
 /**
  * @class KvsValue
- * @brief Represents a flexible value type that can hold various data types, 
+ * @brief Represents a flexible value type that can hold various data types,
  *        including numbers, booleans, strings, null, arrays, and objects.
- * 
- * The KvsValue class provides a type-safe way to store and retrieve values of 
- * different types. It uses a std::variant to hold the underlying value and an 
+ *
+ * The KvsValue class provides a type-safe way to store and retrieve values of
+ * different types. It uses a std::variant to hold the underlying value and an
  * enum to track the type of the value.
- * 
+ *
  * ## Supported Types:
  * - Number (double)
  * - Boolean (bool)
@@ -38,7 +38,7 @@ namespace score::mw::per::kvs {
  * - Null (std::nullptr_t)
  * - Array (std::vector<KvsValue>)
  * - Object (std::unordered_map<std::string, KvsValue>)
- * 
+ *
  * ## Public Methods:
  * - `KvsValue(double number)`: Constructs a KvsValue holding a number.
  * - `KvsValue(bool boolean)`:
@@ -56,11 +56,11 @@ namespace score::mw::per::kvs {
  * @endcode
  */
 
-class KvsValue final{
+class KvsValue final {
 public:
     /* Define the possible types for KvsValue*/
-    using Array = std::vector<KvsValue>;
-    using Object = std::unordered_map<std::string, KvsValue>;
+    using Array = std::vector<std::shared_ptr<KvsValue>>;
+    using Object = std::unordered_map<std::string, std::shared_ptr<KvsValue>>;
 
     /* Enum to represent the type of the value*/
     enum class Type {
@@ -85,8 +85,22 @@ public:
     explicit KvsValue(bool boolean) : value(boolean), type(Type::Boolean) {}
     explicit KvsValue(const std::string& str) : value(str), type(Type::String) {}
     explicit KvsValue(std::nullptr_t) : value(nullptr), type(Type::Null) {}
-    explicit KvsValue(const Array& array) : value(array), type(Type::Array) {}
-    explicit KvsValue(const Object& object) : value(object), type(Type::Object) {}
+    explicit KvsValue(const Array& array) ;
+    explicit KvsValue(const Object& object);
+    explicit KvsValue(const std::vector<KvsValue>& array);
+    explicit KvsValue(const std::unordered_map<std::string, KvsValue>& object);
+
+    /* Copy constructor */
+    KvsValue(const KvsValue& other);
+
+    /* copy assignment operator */
+    KvsValue& operator=(const KvsValue& other);
+
+    /* Move constructor */
+    KvsValue(KvsValue&& other) noexcept : value(std::move(other.value)), type(other.type) {}
+
+    /* move assignment operator */
+    KvsValue& operator=(KvsValue&& other) noexcept;
 
     /* Get the type of the value*/
     Type getType() const { return type; }

--- a/src/cpp/tests/test_kvs_helper.cpp
+++ b/src/cpp/tests/test_kvs_helper.cpp
@@ -14,7 +14,7 @@
 
 
 TEST(kvs_calculate_hash_adler32, calculate_hash_adler32) {
-    /* Test the adler32 hash calculation 
+    /* Test the adler32 hash calculation
     Parsing test is done automatically by the open tests */
 
     std::string test_data = "Hello, World!";
@@ -44,7 +44,7 @@ TEST(kvs_calculate_hash_adler32, calculate_hash_adler32_large_data) {
 }
 
 TEST(kvs_check_hash, check_hash_valid) {
-    
+
     std::string test_data = "Hello, World!";
     uint32_t hash = adler32(test_data);
     std::array<uint8_t, 4> hash_bytes = {
@@ -60,7 +60,7 @@ TEST(kvs_check_hash, check_hash_valid) {
 }
 
 TEST(kvs_check_hash, check_hash_invalid) {
-    
+
     std::string test_data = "Hello, World!";
     uint32_t hash = adler32(test_data);
     std::array<uint8_t, 4> hash_bytes = {
@@ -481,9 +481,9 @@ TEST(kvs_kvsvalue_to_any, kvsvalue_to_any_string) {
 
 TEST(kvs_kvsvalue_to_any, kvsvalue_to_any_array) {
     KvsValue::Array array;
-    array.push_back(KvsValue(true));
-    array.push_back(KvsValue(1.1));
-    array.push_back(KvsValue(std::string("test")));
+    array.push_back(std::make_shared<KvsValue>(true));
+    array.push_back(std::make_shared<KvsValue>(1.1));
+    array.push_back(std::make_shared<KvsValue>(std::string("test")));
     KvsValue array_val(array);
     auto result = kvsvalue_to_any(array_val);
     ASSERT_TRUE(result);
@@ -507,8 +507,8 @@ TEST(kvs_kvsvalue_to_any, kvsvalue_to_any_array) {
 
 TEST(kvs_kvsvalue_to_any, kvsvalue_to_any_object) {
     KvsValue::Object obj;
-    obj.emplace("flag", KvsValue(true)); // Boolean
-    obj.emplace("count", KvsValue(42.0)); // F64
+    obj.emplace("flag", std::make_shared<KvsValue>(true)); // Boolean
+    obj.emplace("count", std::make_shared<KvsValue>(42.0)); // F64
     KvsValue obj_val(obj);
 
     auto result = kvsvalue_to_any(obj_val);
@@ -537,16 +537,16 @@ TEST(kvs_kvsvalue_to_any, kvsvalue_to_any_invalid) {
 
     /* Invalid values in array and object */
     KvsValue::Array array;
-    array.push_back(KvsValue(42.0));
-    array.push_back(invalid);
+    array.push_back(std::make_shared<KvsValue>(42.0));
+    array.push_back(std::make_shared<KvsValue>(invalid));
     KvsValue array_invalid(array);
     result = kvsvalue_to_any(array_invalid);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 
     KvsValue::Object obj;
-    obj.emplace("valid", KvsValue(42.0));
-    obj.emplace("invalid", invalid);
+    obj.emplace("valid", std::make_shared<KvsValue>(42.0));
+    obj.emplace("invalid", std::make_shared<KvsValue>(invalid));
     KvsValue obj_invalid(obj);
     result = kvsvalue_to_any(obj_invalid);
     EXPECT_FALSE(result.has_value());


### PR DESCRIPTION
This PR contains:
- update KvsValue class to use pointers instead of real values.
- update UT compilation issue after updating KvsValue Class.

Bug : https://github.com/eclipse-score/inc_mw_per/issues/62