### PR TITLE
impl: instance pool based on global state

### DIFF
--- a/src/rust/rust_kvs/examples/basic.rs
+++ b/src/rust/rust_kvs/examples/basic.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), ErrorCode> {
         // Build KVS instance for given instance ID and temporary directory.
         // `kvs_load` is explicitly set to `KvsLoad::Optional`, but this is the default value.
         // KVS files are not required.
-        let builder = KvsBuilder::<Kvs>::new(instance_id)
+        let builder = KvsBuilder::new(instance_id)
             .dir(dir_string.clone())
             .kvs_load(KvsLoad::Optional);
         let kvs = builder.build()?;
@@ -64,7 +64,7 @@ fn main() -> Result<(), ErrorCode> {
     {
         // Build KVS instance for given instance ID and temporary directory.
         // `kvs_load` is set to `KvsLoad::Required` - KVS files must already exist from previous KVS instance.
-        let builder = KvsBuilder::<Kvs>::new(instance_id)
+        let builder = KvsBuilder::new(instance_id)
             .dir(dir_string)
             .kvs_load(KvsLoad::Required);
         let kvs = builder.build()?;

--- a/src/rust/rust_kvs/examples/defaults.rs
+++ b/src/rust/rust_kvs/examples/defaults.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), ErrorCode> {
 
     // Build KVS instance for given instance ID and temporary directory.
     // `defaults` is set to `KvsDefaults::Required` - defaults are required.
-    let builder = KvsBuilder::<Kvs>::new(instance_id)
+    let builder = KvsBuilder::new(instance_id)
         .dir(dir_string)
         .defaults(KvsDefaults::Required);
     let kvs = builder.build()?;

--- a/src/rust/rust_kvs/examples/snapshots.rs
+++ b/src/rust/rust_kvs/examples/snapshots.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), ErrorCode> {
         println!("-> `snapshot_count` and `snapshot_max_count` usage");
 
         // Build KVS instance for given instance ID and temporary directory.
-        let builder = KvsBuilder::<Kvs>::new(instance_id).dir(dir_string.clone());
+        let builder = KvsBuilder::new(instance_id).dir(dir_string.clone());
         let kvs = builder.build()?;
 
         let max_count = Kvs::snapshot_max_count() as u32;
@@ -38,7 +38,7 @@ fn main() -> Result<(), ErrorCode> {
         println!("-> `snapshot_restore` usage");
 
         // Build KVS instance for given instance ID and temporary directory.
-        let builder = KvsBuilder::<Kvs>::new(instance_id).dir(dir_string.clone());
+        let builder = KvsBuilder::new(instance_id).dir(dir_string.clone());
         let kvs = builder.build()?;
 
         let max_count = Kvs::snapshot_max_count() as u32;

--- a/src/rust/rust_kvs/src/kvs_api.rs
+++ b/src/rust/rust_kvs/src/kvs_api.rs
@@ -9,13 +9,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
-
-//core and alloc libs
-use core::fmt;
-
 use crate::error_code::ErrorCode;
 use crate::kvs_value::KvsValue;
+use core::fmt;
+use std::path::PathBuf;
 
 /// Instance ID
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -76,15 +73,6 @@ pub enum KvsLoad {
 }
 
 pub trait KvsApi {
-    fn open(
-        instance_id: InstanceId,
-        defaults: KvsDefaults,
-        kvs_load: KvsLoad,
-        dir: Option<String>,
-    ) -> Result<Self, ErrorCode>
-    where
-        Self: Sized;
-
     fn reset(&self) -> Result<(), ErrorCode>;
     fn reset_key(&self, key: &str) -> Result<(), ErrorCode>;
     fn get_all_keys(&self) -> Result<Vec<String>, ErrorCode>;
@@ -107,9 +95,9 @@ pub trait KvsApi {
     fn snapshot_max_count() -> usize
     where
         Self: Sized;
-    fn snapshot_restore(&self, id: SnapshotId) -> Result<(), ErrorCode>;
-    fn get_kvs_filename(&self, id: SnapshotId) -> Result<PathBuf, ErrorCode>;
-    fn get_hash_filename(&self, id: SnapshotId) -> Result<PathBuf, ErrorCode>;
+    fn snapshot_restore(&self, snapshot_id: SnapshotId) -> Result<(), ErrorCode>;
+    fn get_kvs_filename(&self, snapshot_id: SnapshotId) -> Result<PathBuf, ErrorCode>;
+    fn get_hash_filename(&self, snapshot_id: SnapshotId) -> Result<PathBuf, ErrorCode>;
 }
 
 #[cfg(test)]

--- a/src/rust/rust_kvs/src/kvs_backend.rs
+++ b/src/rust/rust_kvs/src/kvs_backend.rs
@@ -10,19 +10,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error_code::ErrorCode;
+use crate::kvs_api::{InstanceId, SnapshotId};
 use crate::kvs_value::KvsMap;
-
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// KVS backend interface.
 pub trait KvsBackend {
     /// Load KvsMap from given file.
-    fn load_kvs(
-        source_path: PathBuf,
-        verify_hash: bool,
-        hash_source: Option<PathBuf>,
-    ) -> Result<KvsMap, ErrorCode>;
+    fn load_kvs(kvs_path: &Path, hash_path: Option<&PathBuf>) -> Result<KvsMap, ErrorCode>;
 
     /// Store KvsMap at given file path.
-    fn save_kvs(kvs: &KvsMap, destination_path: PathBuf, add_hash: bool) -> Result<(), ErrorCode>;
+    fn save_kvs(
+        kvs_map: &KvsMap,
+        kvs_path: &Path,
+        hash_path: Option<&PathBuf>,
+    ) -> Result<(), ErrorCode>;
+}
+
+/// KVS path resolver interface.
+pub trait KvsPathResolver {
+    /// Get KVS file name.
+    fn kvs_file_name(instance_id: InstanceId, snapshot_id: SnapshotId) -> String;
+
+    /// Get KVS file path in working directory.
+    fn kvs_file_path(
+        working_dir: &Path,
+        instance_id: InstanceId,
+        snapshot_id: SnapshotId,
+    ) -> PathBuf;
+
+    /// Get hash file name.
+    fn hash_file_name(instance_id: InstanceId, snapshot_id: SnapshotId) -> String;
+
+    /// Get hash file path in working directory.
+    fn hash_file_path(
+        working_dir: &Path,
+        instance_id: InstanceId,
+        snapshot_id: SnapshotId,
+    ) -> PathBuf;
+
+    /// Get defaults file name.
+    fn defaults_file_name(instance_id: InstanceId) -> String;
+
+    /// Get defaults file path in working directory.
+    fn defaults_file_path(working_dir: &Path, instance_id: InstanceId) -> PathBuf;
 }

--- a/src/rust/rust_kvs/src/kvs_mock.rs
+++ b/src/rust/rust_kvs/src/kvs_mock.rs
@@ -10,7 +10,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error_code::ErrorCode;
-use crate::kvs_api::{InstanceId, KvsApi, KvsDefaults, KvsLoad, SnapshotId};
+use crate::kvs_api::{KvsApi, SnapshotId};
 use crate::kvs_value::{KvsMap, KvsValue};
 use std::sync::{Arc, Mutex};
 
@@ -22,25 +22,19 @@ pub struct MockKvs {
 
 impl Default for MockKvs {
     fn default() -> Self {
-        Self {
-            map: Arc::new(Mutex::new(KvsMap::new())),
-            fail: false,
-        }
+        let map = Arc::new(Mutex::new(KvsMap::new()));
+        Self { map, fail: false }
+    }
+}
+
+impl MockKvs {
+    pub fn new(kvs_map: KvsMap, fail: bool) -> Result<Self, ErrorCode> {
+        let map = Arc::new(Mutex::new(kvs_map));
+        Ok(MockKvs { map, fail })
     }
 }
 
 impl KvsApi for MockKvs {
-    fn open(
-        _instance_id: InstanceId,
-        _defaults: KvsDefaults,
-        _kvs_load: KvsLoad,
-        _dir: Option<String>,
-    ) -> Result<Self, ErrorCode> {
-        Ok(MockKvs {
-            map: Arc::new(Mutex::new(KvsMap::new())),
-            fail: false,
-        })
-    }
     fn reset(&self) -> Result<(), ErrorCode> {
         if self.fail {
             return Err(ErrorCode::UnmappedError);

--- a/src/rust/rust_kvs/src/lib.rs
+++ b/src/rust/rust_kvs/src/lib.rs
@@ -18,7 +18,7 @@
 //! [Adler32](https://crates.io/crates/adler32) crate. No other direct dependencies are used
 //! besides the Rust `std` library.
 //!
-//! The key-value-storage is opened or initialized with [`KvsBuilder::<Kvs>::new`] where various settings
+//! The key-value-storage is opened or initialized with [`KvsBuilder::new`] where various settings
 //! can be applied before the KVS instance is created.
 //!
 //! All `TinyJSON` provided datatypes can be used:
@@ -57,7 +57,8 @@
 //! use std::collections::HashMap;
 //!
 //! fn main() -> Result<(), ErrorCode> {
-//!     let kvs: Kvs = KvsBuilder::new(InstanceId(0)).dir("").build()?;
+//!     let kvs: Kvs = KvsBuilder::new(InstanceId(0))
+//!         .build()?;
 //!
 //!     kvs.set_value("number", 123.0)?;
 //!     kvs.set_value("bool", true)?;
@@ -136,18 +137,19 @@ pub mod kvs;
 pub mod kvs_api;
 mod kvs_backend;
 pub mod kvs_builder;
+pub mod kvs_mock;
 pub mod kvs_value;
 
-pub mod kvs_mock;
-
-pub type Kvs = kvs::GenericKvs<json_backend::JsonBackend>;
+use json_backend::JsonBackend;
+pub type KvsBuilder = kvs_builder::GenericKvsBuilder<JsonBackend>;
+pub type Kvs = kvs::GenericKvs<JsonBackend>;
 
 /// Prelude module for convenient imports
 pub mod prelude {
     pub use crate::error_code::ErrorCode;
     pub use crate::kvs::GenericKvs;
     pub use crate::kvs_api::{InstanceId, KvsApi, KvsDefaults, KvsLoad, SnapshotId};
-    pub use crate::kvs_builder::KvsBuilder;
+    pub use crate::kvs_builder::GenericKvsBuilder;
     pub use crate::kvs_value::{KvsMap, KvsValue};
-    pub use crate::Kvs;
+    pub use crate::{Kvs, KvsBuilder};
 }

--- a/tests/rust_test_scenarios/src/cit/default_values.rs
+++ b/tests/rust_test_scenarios/src/cit/default_values.rs
@@ -252,7 +252,7 @@ impl Scenario for Checksum {
         {
             // Create instance, flush, store paths to files, close instance.
             let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
-            kvs.flush().expect("Failed to flush KVS instance");
+            kvs.flush().expect("Failed to flush");
             kvs_path = kvs
                 .get_kvs_filename(SnapshotId(0))
                 .expect("Failed to get KVS file path");

--- a/tests/rust_test_scenarios/src/cit/persistency.rs
+++ b/tests/rust_test_scenarios/src/cit/persistency.rs
@@ -35,12 +35,20 @@ impl Scenario for ExplicitFlush {
             }
 
             // Explicit flush.
-            kvs.flush().expect("Failed to flush KVS instance");
+            kvs.flush().expect("Failed to flush");
         }
 
         {
             // Second KVS instance object - used for flush check.
             let kvs = kvs_instance(params).expect("Failed to create KVS instance");
+
+            let snapshot_id = SnapshotId(0);
+            let kvs_path_result = kvs.get_kvs_filename(snapshot_id);
+            let hash_path_result = kvs.get_hash_filename(snapshot_id);
+            info!(
+                kvs_path = format!("{kvs_path_result:?}"),
+                hash_path = format!("{hash_path_result:?}")
+            );
 
             // Get values.
             for (key, _) in key_values.iter() {


### PR DESCRIPTION
KVS implementation:
- Use common instance pool in `KvsBuilder`.
  - All instances with same ID share underlying data.
  - All instances must be instantiated with same set of params.
- Rework `json_backend.rs` and `kvs_backend.rs`.
  - `KvsPathResolver` is temporary, until file usage is abstracted in backend.
- Add `Kvs` and `KvsBuilder` type aliases for default backend.
- Remove `KvsApi::open` and make `GenericKvs::new` crate-visible only.
  - Cannot be used outside of crate - `KvsBuilder` must be used.
- Rename `get_kvs_filename` and `get_hash_filename` to `get_kvs_file_path` and `get_hash_file_path` .

Examples:
- Change `KvsBuilder::<Kvs>` to `KvsBuilder` (alias for `GenericKvsBuilder<JsonBackend>`).

Tests:
- Rename functions and parameters.
- Use `KvsBuilder` in tests.
- Use various instance IDs to prevent parameter clashes in static instance pool.

KVS tool:
- Rename functions and parameters.

- `KvsBuilder` is initializing KVS for given set of params.
- Future instances must be requested with same set of params.