### PR TITLE
impl: use interior mut for `flush_on_exit`

### DIFF
--- a/src/rust/rust_kvs/examples/flush.rs
+++ b/src/rust/rust_kvs/examples/flush.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), ErrorCode> {
         {
             // Build KVS instance for given instance ID and temporary directory.
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-            let mut kvs = builder.build()?;
+            let kvs = builder.build()?;
 
             // Disable flush on exit.
             kvs.set_flush_on_exit(FlushOnExit::No);
@@ -55,7 +55,7 @@ fn main() -> Result<(), ErrorCode> {
         {
             // Build KVS instance for given instance ID and temporary directory.
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-            let mut kvs = builder.build()?;
+            let kvs = builder.build()?;
 
             // Explicitly enable flush on exit - this is the default.
             kvs.set_flush_on_exit(FlushOnExit::Yes);
@@ -76,7 +76,7 @@ fn main() -> Result<(), ErrorCode> {
         {
             // Build KVS instance for given instance ID and temporary directory.
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-            let mut kvs = builder.build()?;
+            let kvs = builder.build()?;
 
             // Disable flush on exit.
             kvs.set_flush_on_exit(FlushOnExit::No);
@@ -94,7 +94,7 @@ fn main() -> Result<(), ErrorCode> {
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone())
                 .dir(dir_string)
                 .need_kvs(true);
-            let mut kvs = builder.build()?;
+            let kvs = builder.build()?;
             kvs.set_flush_on_exit(FlushOnExit::No);
 
             let k1_key = "k1";

--- a/src/rust/rust_kvs/examples/snapshots.rs
+++ b/src/rust/rust_kvs/examples/snapshots.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), ErrorCode> {
 
         // Build KVS instance for given instance ID and temporary directory.
         let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-        let mut kvs = builder.build()?;
+        let kvs = builder.build()?;
         kvs.set_flush_on_exit(FlushOnExit::No);
 
         let max_count = Kvs::snapshot_max_count() as u32;
@@ -40,7 +40,7 @@ fn main() -> Result<(), ErrorCode> {
 
         // Build KVS instance for given instance ID and temporary directory.
         let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-        let mut kvs = builder.build()?;
+        let kvs = builder.build()?;
         kvs.set_flush_on_exit(FlushOnExit::No);
 
         let max_count = Kvs::snapshot_max_count() as u32;

--- a/src/rust/rust_kvs/src/kvs_api.rs
+++ b/src/rust/rust_kvs/src/kvs_api.rs
@@ -127,7 +127,7 @@ pub trait KvsApi {
     ) -> Result<(), ErrorCode>;
     fn remove_key(&self, key: &str) -> Result<(), ErrorCode>;
     fn flush_on_exit(&self) -> FlushOnExit;
-    fn set_flush_on_exit(&mut self, flush_on_exit: FlushOnExit);
+    fn set_flush_on_exit(&self, flush_on_exit: FlushOnExit);
     fn flush(&self) -> Result<(), ErrorCode>;
     fn snapshot_count(&self) -> usize;
     fn snapshot_max_count() -> usize

--- a/src/rust/rust_kvs/src/kvs_builder.rs
+++ b/src/rust/rust_kvs/src/kvs_builder.rs
@@ -215,7 +215,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn set_flush_on_exit(&mut self, _flush_on_exit: FlushOnExit) {
+        fn set_flush_on_exit(&self, _flush_on_exit: FlushOnExit) {
             unimplemented!()
         }
 

--- a/src/rust/rust_kvs/src/kvs_mock.rs
+++ b/src/rust/rust_kvs/src/kvs_mock.rs
@@ -46,7 +46,7 @@ impl KvsApi for MockKvs {
     fn flush_on_exit(&self) -> FlushOnExit {
         FlushOnExit::No
     }
-    fn set_flush_on_exit(&mut self, _flush_on_exit: FlushOnExit) {}
+    fn set_flush_on_exit(&self, _flush_on_exit: FlushOnExit) {}
     fn reset(&self) -> Result<(), ErrorCode> {
         if self.fail {
             return Err(ErrorCode::UnmappedError);

--- a/src/rust/rust_kvs/tests/cit_persistency.rs
+++ b/src/rust/rust_kvs/tests/cit_persistency.rs
@@ -100,7 +100,7 @@ fn cit_persistency_flush_on_exit_disabled_drop_data() -> Result<(), ErrorCode> {
 
     {
         // First KVS run.
-        let mut kvs = Kvs::open(
+        let kvs = Kvs::open(
             InstanceId(0),
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
@@ -158,7 +158,7 @@ fn cit_persistency_flush_on_exit_disabled_manual_flush() -> Result<(), ErrorCode
 
     {
         // First KVS run.
-        let mut kvs = Kvs::open(
+        let kvs = Kvs::open(
             InstanceId(0),
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,

--- a/tests/rust_test_scenarios/src/test_basic.rs
+++ b/tests/rust_test_scenarios/src/test_basic.rs
@@ -46,7 +46,7 @@ impl Scenario for BasicScenario {
         }
 
         // Create KVS.
-        let mut kvs: Kvs = builder.build().unwrap();
+        let kvs: Kvs = builder.build().unwrap();
         if let Some(flag) = params.flush_on_exit {
             let mode = if flag {
                 FlushOnExit::Yes


### PR DESCRIPTION
This restores previous behavior where flush on exit behavior can be set without marking KVS object as `mut`.