### PR TITLE
impl: make IDs implement `Copy` trait

### DIFF
--- a/src/rust/rust_kvs/examples/basic.rs
+++ b/src/rust/rust_kvs/examples/basic.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), ErrorCode> {
         // Build KVS instance for given instance ID and temporary directory.
         // `need_kvs` is explicitly set to `false`, but this is the default value.
         // KVS files are not required.
-        let builder = KvsBuilder::<Kvs>::new(instance_id.clone())
+        let builder = KvsBuilder::<Kvs>::new(instance_id)
             .dir(dir_string.clone())
             .need_kvs(false);
         let kvs = builder.build()?;

--- a/src/rust/rust_kvs/examples/defaults.rs
+++ b/src/rust/rust_kvs/examples/defaults.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), ErrorCode> {
     let instance_id = InstanceId(0);
 
     // Create and save defaults file.
-    create_defaults_file(dir.path().to_path_buf(), instance_id.clone())?;
+    create_defaults_file(dir.path().to_path_buf(), instance_id)?;
 
     // Build KVS instance for given instance ID and temporary directory.
     // `need_defaults` is set to `true` - defaults are required.

--- a/src/rust/rust_kvs/examples/flush.rs
+++ b/src/rust/rust_kvs/examples/flush.rs
@@ -26,14 +26,14 @@ fn main() -> Result<(), ErrorCode> {
     let instance_id = InstanceId(0);
 
     // KVS and hash file paths.
-    let (kvs_path, hash_path) = get_kvs_path(dir.path().to_path_buf(), instance_id.clone());
+    let (kvs_path, hash_path) = get_kvs_path(dir.path().to_path_buf(), instance_id);
 
     {
         println!("-> disabled `flush_on_exit`");
 
         {
             // Build KVS instance for given instance ID and temporary directory.
-            let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
+            let builder = KvsBuilder::<Kvs>::new(instance_id).dir(dir_string.clone());
             let kvs = builder.build()?;
 
             // Disable flush on exit.
@@ -54,7 +54,7 @@ fn main() -> Result<(), ErrorCode> {
 
         {
             // Build KVS instance for given instance ID and temporary directory.
-            let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
+            let builder = KvsBuilder::<Kvs>::new(instance_id).dir(dir_string.clone());
             let kvs = builder.build()?;
 
             // Explicitly enable flush on exit - this is the default.
@@ -75,7 +75,7 @@ fn main() -> Result<(), ErrorCode> {
 
         {
             // Build KVS instance for given instance ID and temporary directory.
-            let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
+            let builder = KvsBuilder::<Kvs>::new(instance_id).dir(dir_string.clone());
             let kvs = builder.build()?;
 
             // Disable flush on exit.
@@ -91,7 +91,7 @@ fn main() -> Result<(), ErrorCode> {
 
         {
             // Build KVS instance to check current state.
-            let builder = KvsBuilder::<Kvs>::new(instance_id.clone())
+            let builder = KvsBuilder::<Kvs>::new(instance_id)
                 .dir(dir_string)
                 .need_kvs(true);
             let kvs = builder.build()?;

--- a/src/rust/rust_kvs/examples/snapshots.rs
+++ b/src/rust/rust_kvs/examples/snapshots.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), ErrorCode> {
         println!("-> `snapshot_count` and `snapshot_max_count` usage");
 
         // Build KVS instance for given instance ID and temporary directory.
-        let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
+        let builder = KvsBuilder::<Kvs>::new(instance_id).dir(dir_string.clone());
         let kvs = builder.build()?;
         kvs.set_flush_on_exit(FlushOnExit::No);
 
@@ -39,7 +39,7 @@ fn main() -> Result<(), ErrorCode> {
         println!("-> `snapshot_restore` usage");
 
         // Build KVS instance for given instance ID and temporary directory.
-        let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
+        let builder = KvsBuilder::<Kvs>::new(instance_id).dir(dir_string.clone());
         let kvs = builder.build()?;
         kvs.set_flush_on_exit(FlushOnExit::No);
 

--- a/src/rust/rust_kvs/src/kvs.rs
+++ b/src/rust/rust_kvs/src/kvs.rs
@@ -1046,7 +1046,7 @@ mod kvs_tests {
         kvs.flush().unwrap();
         let snapshot_id = SnapshotId(0);
         // Functions below check if file exist.
-        kvs.get_kvs_filename(snapshot_id.clone()).unwrap();
+        kvs.get_kvs_filename(snapshot_id).unwrap();
         kvs.get_hash_filename(snapshot_id).unwrap();
     }
 

--- a/src/rust/rust_kvs/src/kvs_api.rs
+++ b/src/rust/rust_kvs/src/kvs_api.rs
@@ -18,7 +18,7 @@ use crate::error_code::ErrorCode;
 use crate::kvs_value::KvsValue;
 
 /// Instance ID
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct InstanceId(pub usize);
 
 impl fmt::Display for InstanceId {
@@ -34,7 +34,7 @@ impl From<InstanceId> for usize {
 }
 
 /// Snapshot ID
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SnapshotId(pub usize);
 
 impl fmt::Display for SnapshotId {

--- a/src/rust/rust_kvs/src/kvs_builder.rs
+++ b/src/rust/rust_kvs/src/kvs_builder.rs
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_builder_only_instance_id() {
         let instance_id = InstanceId(42);
-        let builder = KvsBuilder::<StubKvs>::new(instance_id.clone());
+        let builder = KvsBuilder::<StubKvs>::new(instance_id);
         let kvs = builder.build().unwrap();
         assert_eq!(kvs.instance_id().clone(), instance_id);
         assert_eq!(kvs.need_defaults().clone(), OpenNeedDefaults::Optional);
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     fn test_builder_need_defaults() {
         let instance_id = InstanceId(1);
-        let builder = KvsBuilder::<StubKvs>::new(instance_id.clone()).need_defaults(true);
+        let builder = KvsBuilder::<StubKvs>::new(instance_id).need_defaults(true);
         let kvs = builder.build().unwrap();
         assert_eq!(kvs.instance_id().clone(), instance_id);
         assert_eq!(kvs.need_defaults().clone(), OpenNeedDefaults::Required);
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn test_builder_need_kvs() {
         let instance_id = InstanceId(1);
-        let builder = KvsBuilder::<StubKvs>::new(instance_id.clone()).need_kvs(true);
+        let builder = KvsBuilder::<StubKvs>::new(instance_id).need_kvs(true);
         let kvs = builder.build().unwrap();
         assert_eq!(kvs.instance_id().clone(), instance_id);
         assert_eq!(kvs.need_defaults().clone(), OpenNeedDefaults::Optional);
@@ -284,7 +284,7 @@ mod tests {
     fn test_builder_dir() {
         let instance_id = InstanceId(1);
         let dir = "/tmp/test_kvs".to_string();
-        let builder = KvsBuilder::<StubKvs>::new(instance_id.clone()).dir(dir.clone());
+        let builder = KvsBuilder::<StubKvs>::new(instance_id).dir(dir.clone());
         let kvs = builder.build().unwrap();
         assert_eq!(kvs.instance_id().clone(), instance_id);
         assert_eq!(kvs.need_defaults().clone(), OpenNeedDefaults::Optional);
@@ -296,7 +296,7 @@ mod tests {
     fn test_builder_chained() {
         let instance_id = InstanceId(1);
         let dir = "/tmp/test_kvs".to_string();
-        let builder = KvsBuilder::<StubKvs>::new(instance_id.clone())
+        let builder = KvsBuilder::<StubKvs>::new(instance_id)
             .need_defaults(true)
             .need_kvs(true)
             .dir(dir.clone());

--- a/src/rust/rust_kvs/tests/cit_default_values.rs
+++ b/src/rust/rust_kvs/tests/cit_default_values.rs
@@ -17,7 +17,7 @@ use tinyjson::{JsonGenerator, JsonValue};
 fn write_defaults_file(
     dir_string: &Path,
     data: HashMap<String, JsonValue>,
-    instance: &InstanceId,
+    instance: InstanceId,
 ) -> Result<(), ErrorCode> {
     let filepath = dir_string.join(format!("kvs_{instance}_default.json"));
 
@@ -64,21 +64,21 @@ fn cit_persistency_default_values() -> Result<(), ErrorCode> {
     write_defaults_file(
         dir.path(),
         HashMap::from([(keyname.clone(), JsonValue::from(default_value))]),
-        &default_id,
+        default_id,
     )?;
 
     // Assertions.
     {
         // KVS instance with defaults.
         let kvs_with_defaults = Kvs::open(
-            default_id.clone(),
+            default_id,
             OpenNeedDefaults::Required,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
         // KVS instance without defaults.
         let kvs_without_defaults = Kvs::open(
-            non_default_id.clone(),
+            non_default_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
@@ -124,14 +124,14 @@ fn cit_persistency_default_values() -> Result<(), ErrorCode> {
     {
         // KVS instance with defaults.
         let kvs_with_defaults = Kvs::open(
-            default_id.clone(),
+            default_id,
             OpenNeedDefaults::Required,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
         // KVS instance without defaults.
         let kvs_without_defaults = Kvs::open(
-            non_default_id.clone(),
+            non_default_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
@@ -167,7 +167,7 @@ fn cit_persistency_default_values_optional() -> Result<(), ErrorCode> {
     write_defaults_file(
         dir.path(),
         HashMap::from([(keyname.clone(), JsonValue::from(default_value))]),
-        &default_id,
+        default_id,
     )
     .unwrap();
 
@@ -176,7 +176,7 @@ fn cit_persistency_default_values_optional() -> Result<(), ErrorCode> {
         // KVS instance with present defaults file and optional defaults setting
         // (should load defaults).
         let kvs_optional_defaults = Kvs::open(
-            default_id.clone(),
+            default_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
@@ -213,14 +213,14 @@ fn cit_persistency_defaults_enabled_values_removal() -> Result<(), ErrorCode> {
     write_defaults_file(
         dir.path(),
         HashMap::from([(keyname.clone(), JsonValue::from(default_value))]),
-        &default_id,
+        default_id,
     )?;
 
     // Assertions.
     {
         // KVS instance with defaults.
         let kvs_with_defaults = Kvs::open(
-            default_id.clone(),
+            default_id,
             OpenNeedDefaults::Required,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
@@ -310,7 +310,7 @@ fn cit_persistency_invalid_default_values() -> Result<(), ErrorCode> {
 
     // Assertions: opening should fail due to invalid JSON
     let kvs = Kvs::open(
-        default_id.clone(),
+        default_id,
         OpenNeedDefaults::Required,
         OpenNeedKvs::Optional,
         Some(dir_string.clone()),
@@ -343,14 +343,14 @@ fn cit_persistency_reset_all_default_values() -> Result<(), ErrorCode> {
             (keyname1.clone(), JsonValue::from(default_value)),
             (keyname2.clone(), JsonValue::from(default_value)),
         ]),
-        &default_id,
+        default_id,
     )?;
 
     // Assertions.
     {
         // KVS instance with defaults.
         let kvs_with_defaults = Kvs::open(
-            default_id.clone(),
+            default_id,
             OpenNeedDefaults::Required,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),

--- a/src/rust/rust_kvs/tests/cit_multiple_kvs.rs
+++ b/src/rust/rust_kvs/tests/cit_multiple_kvs.rs
@@ -98,14 +98,14 @@ fn cit_persistency_multiple_instances_same_id_common_value() -> Result<(), Error
     {
         // Create first KVS instance.
         let kvs1 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
         // Create second KVS instance.
         let kvs2 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
@@ -120,13 +120,13 @@ fn cit_persistency_multiple_instances_same_id_common_value() -> Result<(), Error
     {
         // Second KVS run.
         let kvs1 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
         let kvs2 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
@@ -165,14 +165,14 @@ fn cit_persistency_multiple_instances_same_id_interfere() -> Result<(), ErrorCod
     {
         // Create first KVS instance.
         let kvs1 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
         // Create second KVS instance.
         let kvs2 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
@@ -187,13 +187,13 @@ fn cit_persistency_multiple_instances_same_id_interfere() -> Result<(), ErrorCod
     {
         // Second KVS run.
         let kvs1 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
         let kvs2 = Kvs::open(
-            instance_id.clone(),
+            instance_id,
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),

--- a/src/rust/rust_kvs/tests/cit_snapshots.rs
+++ b/src/rust/rust_kvs/tests/cit_snapshots.rs
@@ -112,7 +112,7 @@ fn cit_snapshots_snapshot_restore_previous_snapshot() -> Result<(), ErrorCode> {
     // Arrange.
     let instance_id = InstanceId(0);
     let num_snapshots = 4;
-    let kvs = init_kvs(instance_id.clone(), dir_string, num_snapshots)?;
+    let kvs = init_kvs(instance_id, dir_string, num_snapshots)?;
 
     // Assert.
     kvs.snapshot_restore(SnapshotId(3))?;
@@ -129,7 +129,7 @@ fn cit_snapshots_snapshot_restore_current_snapshot() -> Result<(), ErrorCode> {
     // Arrange.
     let instance_id = InstanceId(0);
     let num_snapshots = 2;
-    let kvs = init_kvs(instance_id.clone(), dir_string.clone(), num_snapshots)?;
+    let kvs = init_kvs(instance_id, dir_string.clone(), num_snapshots)?;
 
     // Assert.
     let result = kvs.snapshot_restore(SnapshotId(0));
@@ -146,7 +146,7 @@ fn cit_snapshots_snapshot_restore_nonexisting_snapshot() -> Result<(), ErrorCode
     // Arrange.
     let instance_id = InstanceId(0);
     let num_snapshots = 2;
-    let kvs = init_kvs(instance_id.clone(), dir_string.clone(), num_snapshots)?;
+    let kvs = init_kvs(instance_id, dir_string.clone(), num_snapshots)?;
 
     // Assert.
     let result = kvs.snapshot_restore(SnapshotId(3));
@@ -163,7 +163,7 @@ fn cit_snapshots_get_kvs_filename_existing_snapshot() -> Result<(), ErrorCode> {
     // Arrange.
     let instance_id = InstanceId(0);
     let num_snapshots = 2;
-    let kvs = init_kvs(instance_id.clone(), dir_string.clone(), num_snapshots)?;
+    let kvs = init_kvs(instance_id, dir_string.clone(), num_snapshots)?;
 
     // Assert.
     let last_snapshot_index = num_snapshots - 1;
@@ -204,7 +204,7 @@ fn cit_snapshots_get_hash_filename_existing_snapshot() -> Result<(), ErrorCode> 
     // Arrange.
     let instance_id = InstanceId(0);
     let num_snapshots = 2;
-    let kvs = init_kvs(instance_id.clone(), dir_string.clone(), num_snapshots)?;
+    let kvs = init_kvs(instance_id, dir_string.clone(), num_snapshots)?;
 
     // Assert.
     let last_snapshot_index = num_snapshots - 1;


### PR DESCRIPTION
It's a usize underneath, there's no need explicit `clone` everywhere.