### PR TITLE
testing: improve test env selection

### DIFF
--- a/tests/python_test_cases/requirements.txt
+++ b/tests/python_test_cases/requirements.txt
@@ -1,1 +1,1 @@
-testing-utils @ git+https://github.com/qorix-group/testing_tools.git@v0.2.0
+testing-utils @ git+https://github.com/qorix-group/testing_tools.git@v0.2.2

--- a/tests/python_test_cases/tests/common_scenario.py
+++ b/tests/python_test_cases/tests/common_scenario.py
@@ -1,9 +1,25 @@
 from pathlib import Path
 import pytest
-from testing_utils import Scenario, LogContainer
+from testing_utils import Scenario, LogContainer, BuildTools, BazelTools
+
+
+class ResultCode:
+    """
+    Test scenario exit codes.
+    """
+
+    SUCCESS = 0
+    PANIC = 101
+    SIGKILL = -9
+    SIGABRT = -6
 
 
 class CommonScenario(Scenario):
+    @pytest.fixture(scope="class")
+    def build_tools(self, version: str) -> BuildTools:
+        assert version in ("cpp", "rust")
+        return BazelTools(option_prefix=version)
+
     @pytest.fixture(scope="class")
     def logs_target(self, target_path: Path, logs: LogContainer) -> LogContainer:
         """
@@ -16,7 +32,7 @@ class CommonScenario(Scenario):
         logs : LogContainer
             Unfiltered logs.
         """
-        return logs.get_logs_by_field(field="target", pattern=f"{target_path.name}.*")
+        return logs.get_logs(field="target", pattern=f"{target_path.name}.*")
 
     @pytest.fixture(scope="class")
     def logs_info_level(self, logs_target: LogContainer) -> LogContainer:
@@ -28,7 +44,7 @@ class CommonScenario(Scenario):
         logs_target : LogContainer
             Logs with messages generated strictly by the tested code.
         """
-        return logs_target.get_logs_by_field(field="level", value="INFO")
+        return logs_target.get_logs(field="level", value="INFO")
 
     @pytest.fixture(autouse=True)
     def print_to_report(

--- a/tests/python_test_cases/tests/test_basic.py
+++ b/tests/python_test_cases/tests/test_basic.py
@@ -4,15 +4,11 @@ Smoke test for Rust-C++ tests.
 
 from typing import Any
 import pytest
-from testing_utils import (
-    BazelTools,
-    BuildTools,
-    LogContainer,
-    ScenarioResult,
-)
-from common_scenario import CommonScenario
+from testing_utils import LogContainer, ScenarioResult
+from common_scenario import CommonScenario, ResultCode
 
 
+@pytest.mark.parametrize("version", ["cpp", "rust"], scope="class")
 class TestBasic(CommonScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self, *_, **__) -> str:
@@ -23,20 +19,8 @@ class TestBasic(CommonScenario):
         return {"kvs_parameters": {"instance_id": 2, "flush_on_exit": False}}
 
     def test_returncode_ok(self, results: ScenarioResult):
-        assert results.return_code == 0
+        assert results.return_code == ResultCode.SUCCESS
 
     def test_trace_ok(self, logs_target: LogContainer):
-        lc = logs_target.get_logs_by_field("example_key", value="example_value")
+        lc = logs_target.get_logs("example_key", value="example_value")
         assert len(lc) == 1
-
-
-class TestBasicCpp(TestBasic):
-    @pytest.fixture(scope="class")
-    def build_tools(self, *_, **__) -> BuildTools:
-        return BazelTools(option_prefix="cpp")
-
-
-class TestBasicRust(TestBasic):
-    @pytest.fixture(scope="class")
-    def build_tools(self, *_, **__) -> BuildTools:
-        return BazelTools(option_prefix="rust")

--- a/tests/python_test_cases/tests/test_cit_supported_datatypes.py
+++ b/tests/python_test_cases/tests/test_cit_supported_datatypes.py
@@ -3,8 +3,10 @@ from abc import abstractmethod
 from typing import Any
 
 import pytest
-from common_scenario import CommonScenario
-from testing_utils import BazelTools, BuildTools, LogContainer, ScenarioResult
+from common_scenario import CommonScenario, ResultCode
+from testing_utils import ScenarioResult, LogContainer
+
+pytestmark = pytest.mark.parametrize("version", ["rust"], scope="class")
 
 
 @pytest.mark.PartiallyVerifies(
@@ -25,15 +27,10 @@ class TestSupportedDatatypesKeys(CommonScenario):
     def test_config(self) -> dict[str, Any]:
         return {"kvs_parameters": {"instance_id": 1, "flush_on_exit": False}}
 
-    @pytest.fixture(scope="class", params=["rust"])
-    def build_tools(self, request: pytest.FixtureRequest) -> BuildTools:
-        version = request.param
-        return BazelTools(option_prefix=version)
-
     def test_ok(self, results: ScenarioResult, logs_info_level: LogContainer) -> None:
-        assert results.return_code == 0
+        assert results.return_code == ResultCode.SUCCESS
 
-        logs = logs_info_level.get_logs_by_field(field="key", pattern=".*").get_logs()
+        logs = logs_info_level.get_logs(field="key")
         act_keys = set(map(lambda x: x.key, logs))
         exp_keys = {"example", "emoji ✅❗😀", "greek ημα"}
 
@@ -70,18 +67,11 @@ class TestSupportedDatatypesValues(CommonScenario):
     def test_config(self) -> dict[str, Any]:
         return {"kvs_parameters": {"instance_id": 1, "flush_on_exit": False}}
 
-    @pytest.fixture(scope="class", params=["rust"])
-    def build_tools(self, request: pytest.FixtureRequest) -> BuildTools:
-        version = request.param
-        return BazelTools(option_prefix=version)
-
     def test_ok(self, results: ScenarioResult, logs_info_level: LogContainer) -> None:
-        assert results.return_code == 0
+        assert results.return_code == ResultCode.SUCCESS
 
         # Get log containing type and value.
-        logs = logs_info_level.get_logs_by_field(
-            field="key", value=self.exp_key()
-        ).get_logs()
+        logs = logs_info_level.get_logs(field="key", value=self.exp_key())
         assert len(logs) == 1
         log = logs[0]
 

--- a/tests/rust_test_scenarios/src/helpers/kvs_parameters.rs
+++ b/tests/rust_test_scenarios/src/helpers/kvs_parameters.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::path::PathBuf;
 
 /// KVS parameters in serde-compatible format.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct KvsParameters {
     #[serde(deserialize_with = "deserialize_instance_id")]
     pub instance_id: InstanceId,


### PR DESCRIPTION
- Add common build tools method to base class.
- Add `Clone` to `KvsParameters`.
- Add common return codes.