### PR TITLE
testing: env var for rust debug, bazel command

### DIFF
--- a/tests/python_test_cases/conftest.py
+++ b/tests/python_test_cases/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 from testing_utils import BazelTools
@@ -112,6 +113,15 @@ def pytest_runtest_makereport(item, call):
         else:
             command.append(token)
     report.command = " ".join(command)
+    # If bazel is used, modify command
+    if "BAZEL_VERSION" in os.environ:
+        report.command = report.command.replace(
+            "tests/",
+            "bazel run //tests/",
+        ).replace(
+            " --name",
+            "-- --name",
+        )
 
     # Store failed command for printing in summary
     if report.failed:

--- a/tests/python_test_cases/pytest.ini
+++ b/tests/python_test_cases/pytest.ini
@@ -7,3 +7,6 @@ markers =
         Description
         TestType
         DerivationTechnique
+
+; Additional environment variables
+env = D:RUST_BACKTRACE = 1

--- a/tests/python_test_cases/requirements.txt
+++ b/tests/python_test_cases/requirements.txt
@@ -1,1 +1,2 @@
+pytest-env==1.1.5
 testing-utils @ git+https://github.com/qorix-group/testing_tools.git@v0.2.2


### PR DESCRIPTION
Set debug backtrace for rust scenarios. Bazel specific run instructions for failed tests.