### PR TITLE
impl: fix `coverage_nightly` unexpected cfgs error

### DIFF
--- a/src/rust/rust_kvs/Cargo.toml
+++ b/src/rust/rust_kvs/Cargo.toml
@@ -9,3 +9,6 @@ tinyjson.workspace = true
 
 [dev-dependencies]
 tempfile = "3.20"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }


### PR DESCRIPTION
Add `coverage_nightly` to `[lints.rust]` section of `Cargo.toml`.