### PR TITLE
testing: enable `TestSameInstanceIdDifferentValue`

### DIFF
--- a/tests/python_test_cases/tests/test_cit_multiple_kvs.py
+++ b/tests/python_test_cases/tests/test_cit_multiple_kvs.py
@@ -84,9 +84,6 @@ class TestSameInstanceIdSameValue(CommonScenario):
         assert log1.value == log2.value
 
 
-@pytest.mark.skip(
-    reason="Race condition between set values - to be fixed with instance pool"
-)
 @pytest.mark.PartiallyVerifies(
     ["comp_req__persistency__multi_instance", "comp_req__persistency__concurrency"]
 )


### PR DESCRIPTION
Test was disabled due to race condition.
Behavior is now well defined due to instance pool being used.