### PR TITLE
Use Rust feature from S-CORE devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,4 @@
 {
     "name": "eclipse-s-core",
-    "image": "ghcr.io/eclipse-score/devcontainer:latest",
-    "features": {
-        "ghcr.io/devcontainers/features/rust:1.5.0": {
-            "version": "1.83.0",
-            "components": [
-                "cargo",
-                "clippy",
-                // "miri", // only available at nightly
-                // "rust-analyzer", // already provided by the image
-                "rust-src",
-                "rustfmt"
-            ]
-        }
-    }
+    "image": "ghcr.io/eclipse-score/devcontainer:latest"
 }


### PR DESCRIPTION
Having the Rust feature at the central image improves the first setup time of the devcontainer in this repo. In addition all S-CORE repos have the same tooling and look and feel inside the devcontainer.